### PR TITLE
the `Utility::__call()` method now correctly handles properties with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 3.x branch
 ## 3.0 branch
 ### 3.0.4
+* the `Utility::__call()` method now correctly handles properties with an initial capital letter. This means that
+  `BackupExport()` and `BackupImport()` magically implement the `connection()` method, which allows you to set up the
+    connection even at runtime;
 * for testing with real drivers, a configuration for _Docker_ is proposed and used (see the `README.md` file);
 * by default, the GitHub's actions now use `mariadb` (instead of `mysql`). Improved the entire configuration;
 * fixed https://github.com/mirko-pagliai/cakephp-database-backup/security/dependabot/2;

--- a/src/Utility/BackupExport.php
+++ b/src/Utility/BackupExport.php
@@ -27,8 +27,6 @@ use function Cake\I18n\__d;
  * Utility to export databases.
  *
  * @method \DatabaseBackup\Utility\BackupExport compression(\DatabaseBackup\Compression|string|null $compression)
- * @method \DatabaseBackup\Utility\BackupExport filename(string $filename)
- * @method \DatabaseBackup\Utility\BackupExport timeout(int $timeout)
  */
 class BackupExport extends Utility
 {

--- a/src/Utility/BackupImport.php
+++ b/src/Utility/BackupImport.php
@@ -25,9 +25,6 @@ use function Cake\I18n\__d;
 
 /**
  * Utility to import databases.
- *
- * @method \DatabaseBackup\Utility\BackupImport filename(string $filename)
- * @method \DatabaseBackup\Utility\BackupImport timeout(int $timeout)
  */
 class BackupImport extends Utility
 {

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -30,6 +30,10 @@ use function Cake\I18n\__d;
  * Abstract utility.
  *
  * Provides methods and properties common to utility classes.
+ *
+ * @method $this connection(ConnectionInterface|string $connection)
+ * @method $this filename(string $filename)
+ * @method $this timeout(int $timeout)
  */
 abstract class Utility
 {
@@ -103,6 +107,9 @@ abstract class Utility
      */
     public function __call(string $name, array $arguments)
     {
+        if (property_exists($this, ucfirst($name))) {
+            $name = ucfirst($name);
+        }
         if (!property_exists($this, $name)) {
             throw new BadMethodCallException(sprintf('Method `%s::%s()` does not exist', $this::class, $name));
         }

--- a/tests/TestCase/Utility/UtilityTest.php
+++ b/tests/TestCase/Utility/UtilityTest.php
@@ -42,6 +42,24 @@ class UtilityTest extends TestCase
     /**
      * @inheritDoc
      */
+    public static function setUpBeforeClass(): void
+    {
+        ConnectionManager::setConfig('test', new FakeConnection());
+        ConnectionManager::setConfig('test_another_connection', new FakeConnection(['name' => 'test_another_connection']));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        ConnectionManager::drop('test');
+        ConnectionManager::drop('test_another_connection');
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function setUp(): void
     {
         parent::setUp();
@@ -53,12 +71,11 @@ class UtilityTest extends TestCase
      * @link \DatabaseBackup\Utility\Utility::$connection
      */
     #[Test]
-    #[TestWith([new FakeConnection()])]
-    #[TestWith(['test'])]
-    public function testConnectionProperty(mixed $connection): void
+    #[TestWith([new FakeConnection(), 'test'])]
+    #[TestWith(['test', 'test'])]
+    #[TestWith(['test_another_connection', 'test_another_connection'])]
+    public function testConnectionProperty(string|ConnectionInterface $connection, string $expectedNameConnection): void
     {
-        ConnectionManager::setConfig('test', new FakeConnection());
-
         //Default value, without calling the setter
         $this->assertSame('test', $this->Utility->Connection->config()['name']);
 
@@ -66,10 +83,8 @@ class UtilityTest extends TestCase
 
         $result = $this->Utility->Connection;
 
-        ConnectionManager::drop('test');
-
         $this->assertInstanceOf(ConnectionInterface::class, $result);
-        $this->assertSame('test', $result->config()['name']);
+        $this->assertSame($expectedNameConnection, $result->config()['name']);
     }
 
     /**
@@ -138,7 +153,24 @@ class UtilityTest extends TestCase
         $this->Utility->timeout = -1;
     }
 
+
     /**
+     * @link \DatabaseBackup\Utility\Utility::__call()
+     */
+    #[Test]
+    public function testCallMagicMethod(): void
+    {
+        $this->Utility->connection('test_another_connection');
+
+        $result = $this->Utility->Connection;
+
+        $this->assertInstanceOf(ConnectionInterface::class, $result);
+        $this->assertSame('test_another_connection', $result->config()['name']);
+    }
+
+    /**
+     * Tests for `__call()` magic method, with a non-existing method.
+     *
      * @link \DatabaseBackup\Utility\Utility::__call()
      */
     #[Test]


### PR DESCRIPTION
…an initial capital letter. This means that `BackupExport()` and `BackupImport()` magically implement the `connection()` method, which allows you to set up the connection even at runtime